### PR TITLE
Suggestion: consolidate fiber switching mechanisms

### DIFF
--- a/proposals/fibers/Explainer.md
+++ b/proposals/fibers/Explainer.md
@@ -78,9 +78,9 @@ When the active fiber returns normally or exceptionally:
 
 The resume stack maintains several important invariants (with trivial proofs by induction on execution traces):
 
-    1. The active fiber is always on top of the resume stack.
-    2. The root fiber for the current computation is always at the base of the resume stack.
-    3. No fiber appears more than once in the resume stack, so uncaught exceptions always reach the root.
+ 1. The active fiber is always on top of the resume stack.
+ 2. The root fiber for the current computation is always at the base of the resume stack.
+ 3. No fiber appears more than once in the resume stack, so uncaught exceptions always reach the root.
 
 [^c]: Alternatively, we could have fibers trap when their top-level function returns or propagates an exception, but then we would have to special-case root fibers to allow them to return or propagate exceptions to the host normally. This would also inhibit optimizations that allow fibers that return without ever suspending to be no more expensive than function calls, since the only nontrapping way to leave a fiber would be suspending.
 

--- a/proposals/fibers/Explainer.md
+++ b/proposals/fibers/Explainer.md
@@ -91,7 +91,7 @@ The resume stack maintains several important invariants (with trivial proofs by 
 Every time a fiber suspends itself and resumes another fiber, that transfer of control is a _resumption event_ with an associated tag that indicates the reason for the event.
 It's possible for resumption events to carry values from the suspending fiber to the resuming fiber as well, and the event tag specifies the types of those values so the resuming fiber can receive them properly.
 
-Event tag declarations are the same as for the tags in the [exception handling proposal(https://github.com/WebAssembly/exception-handling):
+Event tag declarations are the same as for the tags in the [exception handling proposal](https://github.com/WebAssembly/exception-handling):
 
 ```
 (tag $e (param t*))


### PR DESCRIPTION
We can consolidate suspending and resuming into a single mechanism by 1) making the simplifying assumption that the toolchain can always arrange for suspending fibers have access to the identity of the next fiber that should run, and 2) considering resume ancestors to be suspended and eligible to switch to.

In particular, `fiber.suspend f` is analogous to `fiber.resume_to parent(f)`, `fiber.resume f` is analogous to `fiber.resume_to f`.

This gives a flatter and more uniform model of fibers in which the resume stack controls normal and exceptional returns from fibers, but has no bearing on how fibers otherwise switch between each other.

Note that with this change the root fiber needs an identity so it can be switched to. I don't see any downside to having a `fiber.current` instruction to facilitate this. That would also allow the fiber-self argument to fiber functions to be removed.

Also note that a further simplification would be to remove `fiber.switch`, since AFAICT toolchains should be able to have the resume ancestor participate in the switch. I've kept that instruction in for now to minimize the delta.

We could also remove `fiber.retire` (in favor of `fiber.retireto`) under the assumption that the toolchain can make switch targets available. And we could remove `fiber.retireto` just like we could remove `fiber.switch` under the assumption that the toolchain can arrange for resume ancestors to participate in fiber management.

[rendered](https://github.com/tlively/stack-switching/blob/patch-3/proposals/fibers/Explainer.md)