### PR TITLE
[explainer] Fix constraints and refactor handlers

### DIFF
--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -214,7 +214,7 @@ This abbreviation will be formalized with an auxiliary function or other means i
   - `(on $e switch) : t*`
     - iff `C.tags[$e] = tag $ft`
     - and `C.types[$ft] ~~ func [] -> [t*']`
-    - and `t* <: t*'`
+    - and `t'* <: t*`
 
 - `suspend <tagidx>`
   - Send a tagged signal to suspend the current computation.

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -93,7 +93,6 @@ We add two new continuation heap types and their subtyping hierachy:
     - and `te1* <: t*`
     - and `C.types[$ct2] = cont $ft2`
     - and `C.types[$ft2] = [t2*] -> [te2*]`
-    - and `te2* <: t*`
 
 ### Binary format
 The binary format is modified as follows:

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -222,7 +222,7 @@ This abbreviation will be formalized with an auxiliary function or other means i
     - and `C.types[$ft] ~~ func [t1*] -> [t2*]`
 
 - `switch <typeidx> <tagidx>`
-- Switch to executing a given continuation directly, suspending the current execution.
+  - Switch to executing a given continuation directly, suspending the current execution.
   - The suspension and switch are performed from the perspective of a parent `(on $e switch)` handler, determined by the annotated tag.
   - `switch $ct1 $e : [t1* (ref null $ct1)] -> [t2*]`
     - iff `C.tags[$e] = tag $ft`

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -213,7 +213,7 @@ This abbreviation will be formalized with an auxiliary function or other means i
     - and `[t2*] -> [t*] <: [t2'*] -> [t'*]`
   - `(on $e switch) : t*`
     - iff `C.tags[$e] = tag $ft`
-    - and `C.types[$ft] ~~ func [] -> [t*']`
+    - and `C.types[$ft] ~~ func [] -> [t'*]`
     - and `t'* <: t*`
 
 - `suspend <tagidx>`

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -213,8 +213,7 @@ This abbreviation will be formalized with an auxiliary function or other means i
     - and `[t2*] -> [t*] <: [t2'*] -> [t'*]`
   - `(on $e switch) : t*`
     - iff `C.tags[$e] = tag $ft`
-    - and `C.types[$ft] ~~ func [] -> [t'*]`
-    - and `t'* <: t*`
+    - and `C.types[$ft] ~~ func [] -> [t*]`
 
 - `suspend <tagidx>`
   - Send a tagged signal to suspend the current computation.


### PR DESCRIPTION
 - Refactor the rules for handlers out so they do not need to be repeated for both `resume` and `resume_throw`.
 - Fix the constraint on the tag type in `(on $e switch)` handlers to ensure the tag result type is equal to the continuation return type. The tag result type must be a subtype of the resume result type to ensure the switched-to continuation has a compatible type, and it must also be a supertype to ensure the return continuation has a correct type. If we wanted to provide more flexibility here, we could upper bound the switched-to continuation result type with the tag results and lower bound the return continuation result type with the tag parameters, but I can't think of any benefit to doing that.
 - Fix the constraint on the return continuation result type in `switch`. We know the switched-from continuation returns `t*`, so we must type it as returning a supertype of `t*`, not a subtype.
 - Fix some mismatched iteration bugs.