### PR TITLE
[explainer] Note that handler search accounts for event kind

### DIFF
--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -45,7 +45,7 @@ We add two new continuation heap types and their subtyping hierachy:
 
 - `resume <typeidx> (on <tagidx> <labelidx>|switch)*`
   - Execute a given continuation.
-    - If the executed continuation suspends with a tagged signal `$t`, the corresponding handler `(tag $t H)` is executed.
+    - If the executed continuation suspends with a tagged signal `$t`, the corresponding handler `(on $t H)` is executed.
   - `resume $ct (on $t H)* : [t1* (ref null? $ct)] -> [t2*]`
     - iff `C.types[$ct] = cont $ft`
     - and `C.types[$ft] = [t1*] -> [t2*]`
@@ -84,7 +84,7 @@ We add two new continuation heap types and their subtyping hierachy:
 
 - `switch <typeidx> <tagidx>`
 - Switch to executing a given continuation directly, suspending the current execution.
-  - The suspension and switch are performed from the perspective of a parent `switch` handler, determined by the annotated tag.
+  - The suspension and switch are performed from the perspective of a parent `(on $e switch)` handler, determined by the annotated tag.
   - `switch $ct1 $e : t1* (ref null $ct1) -> t2*`
     - iff `C.tags[$e] : tag $ft`
     - and `C.types[$ft] : [t*] -> []`
@@ -94,6 +94,10 @@ We add two new continuation heap types and their subtyping hierachy:
     - and `C.types[$ct2] = cont $ft2`
     - and `C.types[$ft2] = [t2*] -> [te2*]`
     - and `te2* <: t*`
+   
+### Execution
+
+The same tag may be used simultaneously by `throw`, `suspend`, `switch`, and their associated handlers. When searching for a handler for an event, only handlers for the matching kind of event are considered, e.g. only `(on $e $l)` handlers can handle `suspend` events and only `(on $e switch)` handlers can handle `switch` events. The handler search continues past handlers for the wrong kind of event, even if they use the correct tag.
 
 ### Binary format
 The binary format is modified as follows:


### PR DESCRIPTION
This came up as a point of ambiguity in a recent discussion, with the other possible design being trapping when the search finds a handler with the correct tag but incorrect event kind.