### PR TITLE
WasmFX reference interpreter: remove heap_type_of_str_type

### DIFF
--- a/test/core/cont.wast
+++ b/test/core/cont.wast
@@ -228,6 +228,22 @@
   (type $c2 (cont $f2))
 )
 
+;; Regression test: non-final continuation types
+(module $non_final
+  (type $ft1 (func (param i32)))
+  (type $ct1 (sub (cont $ft1)))
+
+  (type $ft0 (func))
+  (type $ct0 (sub (cont $ft0)))
+
+  (func $test (param $x (ref $ct1))
+    (i32.const 123)
+    (local.get $x)
+    (cont.bind $ct1 $ct0)
+    (drop)
+  )
+)
+
 ;; Simple state example
 
 (module $state


### PR DESCRIPTION
This fixes #62 by removing the helper function `heap_type_of_str_type` that was introduced solely for typing some WasmFX instructions. All usages of the function are avoided by re-using existing heap types that we already have on hand.

Please note that this PR targets the `wasmfx` branch, it is orthogonal from the recent developments about merging the two proposals.