### PR TITLE
Add full code for $scheduler1 and $scheduler2 examples

### DIFF
--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -371,8 +371,8 @@ code.
 
   ;; Entry point, becomes parent of all tasks.
   ;; Only acts as scheduler when tasks finish.
-  (func $entry
-    ;; initialise $task_queue with initial task
+  (func $entry (param $initial_task (ref $ft))
+    ;; initialise $task_queue with $initial_task
     ...
     (loop $resume_next
       ;; pick $next_task from queue, or return if no more tasks.

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -290,8 +290,8 @@ This approach is illustrated by the following skeleton code.
 
   ;; Entry point, becomes parent of all tasks.
   ;; Also acts as scheduler when tasks yield or finish.
-  (func $entry
-    ;; initialise $task_queue with initial task
+  (func $entry (param $initial_task (ref $ft))
+    ;; initialise $task_queue with $initial_task
     ...
     (loop $resume_next
       ;; pick $next_task from queue, or return if no more tasks.

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -487,6 +487,9 @@ enqueued in the task list, but should instead be cancelled. Cancellation
 can be implemented using another instruction, `resume_throw`, which is
 described later in the document.
 
+Full versions of `$scheduler1` and  `$scheduler2` can be found
+[here](examples/scheduler1.wast) and [here](examples/scheduler2.wast).
+
 ## Instruction set extension
 
 Here we give an informal account of the proposed instruction set

--- a/proposals/stack-switching/examples/scheduler1.wast
+++ b/proposals/stack-switching/examples/scheduler1.wast
@@ -1,0 +1,160 @@
+;; queue of threads
+(module $queue
+
+  (type $ft (func))
+  (type $ct (cont $ft))
+
+  ;; Table as simple queue (keeping it simple, no ring buffer)
+  (table $task_queue 0 (ref null $ct))
+  (global $qdelta i32 (i32.const 10))
+  (global $qback (mut i32) (i32.const 0))
+  (global $qfront (mut i32) (i32.const 0))
+
+  (func $queue_empty (export "queue-empty") (result i32)
+    (i32.eq (global.get $qfront) (global.get $qback))
+  )
+
+  (func $dequeue (export "dequeue") (result (ref null $ct))
+    (local $i i32)
+    (if (call $queue_empty)
+      (then (return (ref.null $ct)))
+    )
+    (local.set $i (global.get $qfront))
+    (global.set $qfront (i32.add (local.get $i) (i32.const 1)))
+    (table.get $task_queue (local.get $i))
+  )
+
+  (func $enqueue (export "enqueue") (param $k (ref null $ct))
+    ;; Check if queue is full
+    (if (i32.eq (global.get $qback) (table.size $task_queue))
+      (then
+        ;; Check if there is enough space in the front to compact
+        (if (i32.lt_u (global.get $qfront) (global.get $qdelta))
+          (then
+            ;; Space is below threshold, grow table instead
+            (drop (table.grow $task_queue (ref.null $ct) (global.get $qdelta)))
+          )
+          (else
+            ;; Enough space, move entries up to head of table
+            (global.set $qback (i32.sub (global.get $qback) (global.get $qfront)))
+            (table.copy $task_queue $task_queue
+              (i32.const 0)         ;; dest = new front = 0
+              (global.get $qfront)  ;; src = old front
+              (global.get $qback)   ;; len = new back = old back - old front
+            )
+            (table.fill $task_queue      ;; null out old entries to avoid leaks
+              (global.get $qback)   ;; start = new back
+              (ref.null $ct)      ;; init value
+              (global.get $qfront)  ;; len = old front = old front - new front
+            )
+            (global.set $qfront (i32.const 0))
+          )
+        )
+      )
+    )
+    (table.set $task_queue (global.get $qback) (local.get $k))
+    (global.set $qback (i32.add (global.get $qback) (i32.const 1)))
+  )
+)
+(register "queue")
+
+(module $scheduler1
+  (type $ft (func))
+  ;; Continuation type of all tasks
+  (type $ct (cont $ft))
+
+
+  (func $task_enqueue (import "queue" "enqueue") (param (ref null $ct)))
+  (func $task_dequeue (import "queue" "dequeue") (result (ref null $ct)))
+  (func $task_queue-empty (import "queue" "queue-empty") (result i32))
+  (func $print_i32 (import "spectest" "print_i32") (param i32))
+
+  ;; Tag used to yield execution in one task and resume another one.
+  (tag $yield)
+
+  ;; Entry point, becomes parent of all tasks.
+  ;; Also acts as scheduler when tasks yield or finish.
+  (func $entry (param $initial_task (ref $ft))
+    (local $next_task (ref null $ct))
+
+    ;; initialise $task_queue with initial task
+    (call $task_enqueue (cont.new $ct (local.get $initial_task)))
+
+    (loop $resume_next
+      ;; pick $next_task from queue, or return if no more tasks.
+      (if (call $task_queue-empty)
+        (then (return))
+        (else (local.set $next_task (call $task_dequeue)))
+      )
+      (block $on_yield (result (ref $ct))
+        (resume $ct (on $yield $on_yield) (local.get $next_task))
+        ;; task finished execution
+        (br $resume_next)
+      )
+      ;; task suspended: put continuation in queue, then loop to determine next
+      ;; one to resume.
+      (call $task_enqueue)
+      (br $resume_next)
+    )
+  )
+
+  ;; To simplify the example, all task_i functions execute this function. Each
+  ;; task has an $id, but this is only used for printing.
+  ;; $to_spawn represents another task that this function will add to the task
+  ;; queue, unless the reference is null.
+  (func $task_impl
+        (param $id i32)
+        (param $to_spawn (ref null $ft))
+
+    (if (ref.is_null (local.get $to_spawn))
+      (then)
+      (else (call $task_enqueue (cont.new $ct (local.get $to_spawn)))))
+
+    (call $print_i32 (local.get $id))
+    (suspend $yield)
+    (call $print_i32 (local.get $id))
+  )
+
+  ;; The actual $task_i functions simply call $task_impl, with i as the value
+  ;; for $id, and $task_(i+1) as the task to spawn, except for $task_3, which
+  ;; does not spawn another task.
+  ;;
+  ;; The observant reader may note that all $task_i functions may be seen as
+  ;; partial applications of $task_impl.
+  ;; Indeed, we could obtain *continuations* running each $task_i from a
+  ;; continuation running $task_impl and cont.bind.
+
+  (func $task_3
+    (i32.const 3)
+    (ref.null $ft)
+    (call $task_impl)
+  )
+  (elem declare func $task_3)
+
+  (func $task_2
+    (i32.const 2)
+    (ref.func $task_3)
+    (call $task_impl)
+  )
+  (elem declare func $task_2)
+
+  (func $task_1
+    (i32.const 1)
+    (ref.func $task_2)
+    (call $task_impl)
+  )
+  (elem declare func $task_1)
+
+  (func $task_0
+    (i32.const 0)
+    (ref.func $task_1)
+    (call $task_impl)
+  )
+  (elem declare func $task_0)
+
+
+  (func (export "main")
+    (call $entry (ref.func $task_0))
+  )
+)
+(invoke "main")

--- a/proposals/stack-switching/examples/scheduler2.wast
+++ b/proposals/stack-switching/examples/scheduler2.wast
@@ -70,8 +70,6 @@
   (func $task-queue-empty (import "queue" "queue-empty") (result i32))
   (func $print-i32 (import "spectest" "print_i32") (param i32))
 
-  (global $taskid (mut i32) (i32.const 0))
-
   ;; Tag used to yield execution in one task and resume another one.
   (tag $yield)
 
@@ -113,24 +111,6 @@
     (call $print-i32 (local.get $id))
   )
 
-  ;; (func $task (type $ft)
-  ;;   (local $id i32)
-  ;;   (local $c (ref null $ct))
-  ;;   (local.set $c (local.get 0))
-  ;;   (if (ref.is_null (local.get $c))
-  ;;     (then)
-  ;;     (else (call $task-enqueue (local.get $c))))
-  ;;   (local.set $id (global.get $taskid))
-  ;;   (global.set $taskid (i32.add (local.get $id) (i32.const 1)))
-
-  ;;   (if (i32.lt_u (local.get $id) (i32.const 4))
-  ;;     (then (call $task-enqueue (cont.new $ct (ref.func $task))))
-  ;;     (else))
-
-  ;;   (call $print-i32 (local.get $id))
-  ;;   (call $yield_to_next)
-  ;;   (call $print-i32 (local.get $id))
-  ;; )
 
   (func $task_4 (type $ft)
     (i32.const 4)

--- a/proposals/stack-switching/examples/scheduler2.wast
+++ b/proposals/stack-switching/examples/scheduler2.wast
@@ -92,24 +92,74 @@
     (return (i32.const 41))
   )
 
-  (func $task (type $ft)
-    (local $id i32)
-    (local $c (ref null $ct))
-    (local.set $c (local.get 0))
+  (func $task_impl
+        (param $id i32)
+        (param $to_spawn (ref null $ft))
+        (param $c (ref null $ct))
+
     (if (ref.is_null (local.get $c))
       (then)
       (else (call $task-enqueue (local.get $c))))
-    (local.set $id (global.get $taskid))
-    (global.set $taskid (i32.add (local.get $id) (i32.const 1)))
 
-    (if (i32.lt_u (local.get $id) (i32.const 4))
-      (then (call $task-enqueue (cont.new $ct (ref.func $task))))
-      (else))
+    (if (ref.is_null (local.get $to_spawn))
+      (then)
+      (else (call $task-enqueue (cont.new $ct (local.get $to_spawn)))))
 
     (call $print-i32 (local.get $id))
     (call $yield_to_next)
     (call $print-i32 (local.get $id))
   )
+
+  ;; (func $task (type $ft)
+  ;;   (local $id i32)
+  ;;   (local $c (ref null $ct))
+  ;;   (local.set $c (local.get 0))
+  ;;   (if (ref.is_null (local.get $c))
+  ;;     (then)
+  ;;     (else (call $task-enqueue (local.get $c))))
+  ;;   (local.set $id (global.get $taskid))
+  ;;   (global.set $taskid (i32.add (local.get $id) (i32.const 1)))
+
+  ;;   (if (i32.lt_u (local.get $id) (i32.const 4))
+  ;;     (then (call $task-enqueue (cont.new $ct (ref.func $task))))
+  ;;     (else))
+
+  ;;   (call $print-i32 (local.get $id))
+  ;;   (call $yield_to_next)
+  ;;   (call $print-i32 (local.get $id))
+  ;; )
+
+  (func $task_4 (type $ft)
+    (i32.const 4)
+    (ref.null $ft)
+    (local.get 0)
+    (call $task_impl)
+  )
+  (elem declare func $task_4)
+
+  (func $task_3 (type $ft)
+    (i32.const 3)
+    (ref.func $task_4)
+    (local.get 0)
+    (call $task_impl)
+  )
+  (elem declare func $task_3)
+
+  (func $task_2 (type $ft)
+    (i32.const 2)
+    (ref.func $task_3)
+    (local.get 0)
+    (call $task_impl)
+  )
+  (elem declare func $task_2)
+
+  (func $task_1 (type $ft)
+    (i32.const 1)
+    (ref.func $task_2)
+    (local.get 0)
+    (call $task_impl)
+  )
+  (elem declare func $task_1)
 
 
   ;; Determines next task to switch to directly.
@@ -135,10 +185,9 @@
     ;; Just return if no other task in queue, making the $yield_to_next call
     ;; a noop.
   )
-  (elem declare func $task)
 
   (func (export "main") (result i32)
-    (call $entry (cont.new $ct (ref.func $task)))
+    (call $entry (cont.new $ct (ref.func $task_1)))
     (return (i32.add (i32.const 1))))
 )
 (assert_return (invoke "main") (i32.const 42))

--- a/proposals/stack-switching/examples/scheduler2.wast
+++ b/proposals/stack-switching/examples/scheduler2.wast
@@ -93,6 +93,14 @@
     )
   )
 
+  ;; To simplify the example, all task_i functions execute this function. Each
+  ;; task has an $id, but this is only used for printing.
+  ;; $to_spawn represents another task that this function will add to the task
+  ;; queue, unless the reference is null.
+  ;; $c corresponds to the continuation parameter of the original $task_i
+  ;; functions.
+  ;; This means that it is the previous continuation we just switch-ed away
+  ;; from, or a null reference if the task was resumed from $entry.
   (func $task_impl
         (param $id i32)
         (param $to_spawn (ref null $ft))
@@ -111,6 +119,14 @@
     (call $print_i32 (local.get $id))
   )
 
+  ;; The actual $task_i functions simply call $task_impl, with i as the value
+  ;; for $id, and $task_(i+1) as the task to spawn, except for $task_4, which
+  ;; does not spawn another task.
+  ;;
+  ;; The observant reader may note that all $task_i functions may be seen as
+  ;; partial applications of $task_impl.
+  ;; Indeed, we could obtain *continuations* running each $task_i from a
+  ;; continuation running $task_impl and cont.bind.
 
   (func $task_4 (type $ft)
     (i32.const 4)

--- a/proposals/stack-switching/examples/scheduler2.wast
+++ b/proposals/stack-switching/examples/scheduler2.wast
@@ -1,0 +1,144 @@
+;; queue of threads
+(module $queue
+  (rec
+    (type $ft (func (param (ref null $ct))))
+    (type $ct (cont $ft)))
+
+  ;; Table as simple queue (keeping it simple, no ring buffer)
+  (table $queue 0 (ref null $ct))
+  (global $qdelta i32 (i32.const 10))
+  (global $qback (mut i32) (i32.const 0))
+  (global $qfront (mut i32) (i32.const 0))
+
+  (func $queue-empty (export "queue-empty") (result i32)
+    (i32.eq (global.get $qfront) (global.get $qback))
+  )
+
+  (func $dequeue (export "dequeue") (result (ref null $ct))
+    (local $i i32)
+    (if (call $queue-empty)
+      (then (return (ref.null $ct)))
+    )
+    (local.set $i (global.get $qfront))
+    (global.set $qfront (i32.add (local.get $i) (i32.const 1)))
+    (table.get $queue (local.get $i))
+  )
+
+  (func $enqueue (export "enqueue") (param $k (ref null $ct))
+    ;; Check if queue is full
+    (if (i32.eq (global.get $qback) (table.size $queue))
+      (then
+        ;; Check if there is enough space in the front to compact
+        (if (i32.lt_u (global.get $qfront) (global.get $qdelta))
+          (then
+            ;; Space is below threshold, grow table instead
+            (drop (table.grow $queue (ref.null $ct) (global.get $qdelta)))
+          )
+          (else
+            ;; Enough space, move entries up to head of table
+            (global.set $qback (i32.sub (global.get $qback) (global.get $qfront)))
+            (table.copy $queue $queue
+              (i32.const 0)         ;; dest = new front = 0
+              (global.get $qfront)  ;; src = old front
+              (global.get $qback)   ;; len = new back = old back - old front
+            )
+            (table.fill $queue      ;; null out old entries to avoid leaks
+              (global.get $qback)   ;; start = new back
+              (ref.null $ct)      ;; init value
+              (global.get $qfront)  ;; len = old front = old front - new front
+            )
+            (global.set $qfront (i32.const 0))
+          )
+        )
+      )
+    )
+    (table.set $queue (global.get $qback) (local.get $k))
+    (global.set $qback (i32.add (global.get $qback) (i32.const 1)))
+  )
+)
+(register "queue")
+
+(module $scheduler2
+  (rec
+    (type $ft (func (param (ref null $ct))))
+    ;; Continuation type of all tasks
+    (type $ct (cont $ft))
+  )
+
+  (func $task-enqueue (import "queue" "enqueue") (param (ref null $ct)))
+  (func $task-dequeue (import "queue" "dequeue") (result (ref null $ct)))
+  (func $task-queue-empty (import "queue" "queue-empty") (result i32))
+  (func $print-i32 (import "spectest" "print_i32") (param i32))
+
+  (global $taskid (mut i32) (i32.const 0))
+
+  ;; Tag used to yield execution in one task and resume another one.
+  (tag $yield)
+
+  ;; Entry point, becomes parent of all tasks.
+  ;; Only acts as scheduler when tasks finish.
+  (func $entry (param $next_task (ref null $ct)) (result i32)
+    (local $default (ref null $ct))
+    (local.set $default (ref.null $ct))
+    (loop $resume_next
+      (resume $ct (on $yield switch)
+        (local.get $default) (local.get $next_task))
+      ;; task finished execution: loop to pick next one
+      (if (call $task-queue-empty)
+        (then)
+        (else (local.set $next_task (call $task-dequeue))
+              (br $resume_next)))
+    )
+    (return (i32.const 41))
+  )
+
+  (func $task (type $ft)
+    (local $id i32)
+    (local $c (ref null $ct))
+    (local.set $c (local.get 0))
+    (if (ref.is_null (local.get $c))
+      (then)
+      (else (call $task-enqueue (local.get $c))))
+    (local.set $id (global.get $taskid))
+    (global.set $taskid (i32.add (local.get $id) (i32.const 1)))
+
+    (if (i32.lt_u (local.get $id) (i32.const 4))
+      (then (call $task-enqueue (cont.new $ct (ref.func $task))))
+      (else))
+
+    (call $print-i32 (local.get $id))
+    (call $yield_to_next)
+    (call $print-i32 (local.get $id))
+  )
+
+
+  ;; Determines next task to switch to directly.
+  (func $yield_to_next
+    (local $next_task (ref null $ct))
+    (block $done
+      (br_if $done (call $task-queue-empty))
+      ;; Switch to $next_task.
+      ;; The switch instruction implicitly passes a reference to the currently
+      ;; executing continuation as an argument to $next_task.
+      (local.set $next_task (call $task-dequeue))
+      (switch $ct $ct $yield (local.get $next_task))
+      (local.set $next_task)
+      (if (ref.is_null (local.get $next_task))
+        (then)
+        (else (call $task-enqueue (local.get $next_task))))
+      ;; If we get here, some other continuation switch-ed directly to us, or
+      ;; $entry resumed us.
+      ;; In the first case, we receive the continuation that switched to us here
+      ;; and we need to enqueue it in the task list.
+      ;; In the second case, the passed continuation reference will be null.
+    )
+    ;; Just return if no other task in queue, making the $yield_to_next call
+    ;; a noop.
+  )
+  (elem declare func $task)
+
+  (func (export "main") (result i32)
+    (call $entry (cont.new $ct (ref.func $task)))
+    (return (i32.add (i32.const 1))))
+)
+(assert_return (invoke "main") (i32.const 42))

--- a/proposals/stack-switching/examples/scheduler2.wast
+++ b/proposals/stack-switching/examples/scheduler2.wast
@@ -122,7 +122,7 @@
   )
 
   ;; The actual $task_i functions simply call $task_impl, with i as the value
-  ;; for $id, and $task_(i+1) as the task to spawn, except for $task_4, which
+  ;; for $id, and $task_(i+1) as the task to spawn, except for $task_3, which
   ;; does not spawn another task.
   ;;
   ;; The observant reader may note that all $task_i functions may be seen as
@@ -130,17 +130,9 @@
   ;; Indeed, we could obtain *continuations* running each $task_i from a
   ;; continuation running $task_impl and cont.bind.
 
-  (func $task_4 (type $ft)
-    (i32.const 4)
-    (ref.null $ft)
-    (local.get 0)
-    (call $task_impl)
-  )
-  (elem declare func $task_4)
-
   (func $task_3 (type $ft)
     (i32.const 3)
-    (ref.func $task_4)
+    (ref.null $ft)
     (local.get 0)
     (call $task_impl)
   )
@@ -161,6 +153,14 @@
     (call $task_impl)
   )
   (elem declare func $task_1)
+
+  (func $task_0 (type $ft)
+    (i32.const 0)
+    (ref.func $task_1)
+    (local.get 0)
+    (call $task_impl)
+  )
+  (elem declare func $task_0)
 
 
   ;; Determines next task to switch to directly.
@@ -192,7 +192,7 @@
   )
 
   (func (export "main")
-    (call $entry (ref.func $task_1))
+    (call $entry (ref.func $task_0))
   )
 )
 (invoke "main")

--- a/proposals/stack-switching/examples/scheduler2.wast
+++ b/proposals/stack-switching/examples/scheduler2.wast
@@ -10,13 +10,13 @@
   (global $qback (mut i32) (i32.const 0))
   (global $qfront (mut i32) (i32.const 0))
 
-  (func $queue-empty (export "queue-empty") (result i32)
+  (func $queue_empty (export "queue-empty") (result i32)
     (i32.eq (global.get $qfront) (global.get $qback))
   )
 
   (func $dequeue (export "dequeue") (result (ref null $ct))
     (local $i i32)
-    (if (call $queue-empty)
+    (if (call $queue_empty)
       (then (return (ref.null $ct)))
     )
     (local.set $i (global.get $qfront))
@@ -65,10 +65,10 @@
     (type $ct (cont $ft))
   )
 
-  (func $task-enqueue (import "queue" "enqueue") (param (ref null $ct)))
-  (func $task-dequeue (import "queue" "dequeue") (result (ref null $ct)))
-  (func $task-queue-empty (import "queue" "queue-empty") (result i32))
-  (func $print-i32 (import "spectest" "print_i32") (param i32))
+  (func $task_enqueue (import "queue" "enqueue") (param (ref null $ct)))
+  (func $task_dequeue (import "queue" "dequeue") (result (ref null $ct)))
+  (func $task_queue-empty (import "queue" "queue-empty") (result i32))
+  (func $print_i32 (import "spectest" "print_i32") (param i32))
 
   ;; Tag used to yield execution in one task and resume another one.
   (tag $yield)
@@ -79,12 +79,12 @@
     (local $next_task (ref null $ct))
 
     ;; initialise $task_queue with initial task
-    (call $task-enqueue (cont.new $ct (local.get $initial_task)))
+    (call $task_enqueue (cont.new $ct (local.get $initial_task)))
 
     (loop $resume_next
-      (if (call $task-queue-empty)
+      (if (call $task_queue-empty)
         (then (return))
-        (else (local.set $next_task (call $task-dequeue)))
+        (else (local.set $next_task (call $task_dequeue)))
       )
       (resume $ct (on $yield switch)
         (ref.null $ct) (local.get $next_task))
@@ -100,15 +100,15 @@
 
     (if (ref.is_null (local.get $c))
       (then)
-      (else (call $task-enqueue (local.get $c))))
+      (else (call $task_enqueue (local.get $c))))
 
     (if (ref.is_null (local.get $to_spawn))
       (then)
-      (else (call $task-enqueue (cont.new $ct (local.get $to_spawn)))))
+      (else (call $task_enqueue (cont.new $ct (local.get $to_spawn)))))
 
-    (call $print-i32 (local.get $id))
+    (call $print_i32 (local.get $id))
     (call $yield_to_next)
-    (call $print-i32 (local.get $id))
+    (call $print_i32 (local.get $id))
   )
 
 
@@ -149,16 +149,16 @@
   (func $yield_to_next
     (local $next_task (ref null $ct))
     (block $done
-      (br_if $done (call $task-queue-empty))
+      (br_if $done (call $task_queue-empty))
       ;; Switch to $next_task.
       ;; The switch instruction implicitly passes a reference to the currently
       ;; executing continuation as an argument to $next_task.
-      (local.set $next_task (call $task-dequeue))
+      (local.set $next_task (call $task_dequeue))
       (switch $ct $ct $yield (local.get $next_task))
       (local.set $next_task)
       (if (ref.is_null (local.get $next_task))
         (then)
-        (else (call $task-enqueue (local.get $next_task))))
+        (else (call $task_enqueue (local.get $next_task))))
       ;; If we get here, some other continuation switch-ed directly to us, or
       ;; $entry resumed us.
       ;; In the first case, we receive the continuation that switched to us here

--- a/proposals/stack-switching/examples/scheduler2.wast
+++ b/proposals/stack-switching/examples/scheduler2.wast
@@ -176,7 +176,7 @@
       ;; Switch to $next_task.
       ;; The switch instruction implicitly passes a reference to the currently
       ;; executing continuation as an argument to $next_task.
-      (switch $ct $ct $yield (local.get $next_task))
+      (switch $ct $yield (local.get $next_task))
       ;; If we get here, some other continuation switch-ed directly to us, or
       ;; $entry resumed us.
       ;; In the first case, we receive the continuation that switched to us here


### PR DESCRIPTION
The third section of the explainer currently compares task scheduling using `resume`/`suspend` vs `switch` using two example modules, `$scheduler1`  and `$scheduler2`. The explainer only contains a skeleton of the actual code.

This PR adds `.wast` files containing full code for these modules and links to them in the explainer. The code is carefully written to follow the structure shown in the explainer.

The code already follows the syntax update coming in #81.

Based on earlier versions of the code created  by @dhil.