### PR TITLE
[Binary format] Encode continuation type index as an `s33`

### DIFF
--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -842,7 +842,7 @@ We extend the binary format of composite types, heap types, and instructions.
 | Opcode | Type            | Parameters | Note |
 | ------ | --------------- | ---------- |------|
 | -0x20  | `func t1* t2*`  | `t1* : vec(valtype)` `t2* : vec(valtype)` | from Wasm 1.0 |
-| -0x23  | `cont $ft`      | `$ft : typeidx` | new |
+| -0x23  | `cont $ft`      | `$ft : s33` | new |
 
 #### Heap Types
 


### PR DESCRIPTION
There is a small inconsistency between the reference implementation in #84 and the explainer. In the explainer we write that the type index `$ft` on `cont $ft` should be encoded as an `u32` in the binary format. However, the reference interpreter actually encodes it as `s33`, similarly to how concrete heap types are encoded.

I do not have a strong preference for either encoding, but I suppose one can argue that the `s33` approach is more forward compatible in the sense that we can encode additional metadata.