### PR TITLE
Gracefully exit on unhandled tag

### DIFF
--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -116,6 +116,7 @@ let input_from get_script run =
   | Eval.Exhaustion (at, msg) -> error at "resource exhaustion" msg
   | Eval.Crash (at, msg) -> error at "runtime crash" msg
   | Eval.Exception (at, msg) -> error at "uncaught exception" msg
+  | Eval.Suspension (at, msg) -> error at "suspension error" msg
   | Encode.Code (at, msg) -> error at "encoding error" msg
   | Script.Error (at, msg) -> error at "script error" msg
   | IO (at, msg) -> error at "i/o error" msg


### PR DESCRIPTION
This patch fixes #92 such that the interpreter exits gracefully on an unhandled tag.
```bash
$ cat test.wast
(module
  (type $f1 (func))
  (type $c1 (cont $f1))
  (tag $e)
  (func $s (suspend $e))
  (elem declare func $s)
  (func (export "main")
    (resume $c1 (cont.new $c1 (ref.func $s)))
  )
)
$ ./wasm test.wast
test.wast:5.12-5.24: suspension error: unhandled tag
```
