### PR TITLE
Fix encoding and decoding of tag imports.

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -1087,7 +1087,7 @@ let import_desc s =
   | 0x01 -> TableImport (table_type s)
   | 0x02 -> MemoryImport (memory_type s)
   | 0x03 -> GlobalImport (global_type s)
-  | 0x04 -> TagImport (at var s)
+  | 0x04 -> TagImport (tag_type s)
   | _ -> error s (pos s - 1) "malformed import kind"
 
 let import s =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -951,7 +951,7 @@ struct
     | TableImport t -> byte 0x01; table_type t
     | MemoryImport t -> byte 0x02; memory_type t
     | GlobalImport t -> byte 0x03; global_type t
-    | TagImport t -> byte 0x04; var t
+    | TagImport t -> byte 0x04; tag_type t
 
   let import im =
     let {module_name; item_name; idesc} = im.it in
@@ -1002,8 +1002,8 @@ struct
     section 6 (vec global) gs (gs <> [])
 
   (* Tag section *)
-  let tag tag =
-    tag_type tag.it.tgtype
+  let tag (t : tag) =
+    byte 0x00; var t.it.tgtype
 
   let tag_section ts =
     section 13 (vec tag) ts (ts <> [])


### PR DESCRIPTION
This patch brings the encoding and decoding of tag imports in sync with the exception handling proposal (as it is integrated into WebAssembly/spec branch `wasm-3.0`).

Resolves #101.