### PR TITLE
Fix arity of generated switcher continuations

### DIFF
--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -114,44 +114,6 @@ let defaultable = function
   | BotT -> assert false
 
 
-(* Conversions & Projections *)
-
-let num_type_of_addr_type = function
-  | I32AT -> I32T
-  | I64AT -> I64T
-
-let addr_type_of_num_type = function
-  | I32T -> I32AT
-  | I64T -> I64AT
-  | _ -> assert false
-
-
-let unpacked_storage_type = function
-  | ValStorageT t -> t
-  | PackStorageT _ -> NumT I32T
-
-let unpacked_field_type (FieldT (_mut, t)) = unpacked_storage_type t
-
-
-let as_func_str_type (st : str_type) : func_type =
-  match st with
-  | DefFuncT ft -> ft
-  | _ -> assert false
-
-let as_struct_str_type (st : str_type) : struct_type =
-  match st with
-  | DefStructT st -> st
-  | _ -> assert false
-
-let as_array_str_type (st : str_type) : array_type =
-  match st with
-  | DefArrayT at -> at
-  | _ -> assert false
-
-let extern_type_of_import_type (ImportT (et, _, _)) = et
-let extern_type_of_export_type (ExportT (et, _)) = et
-
-
 (* Filters *)
 
 let funcs = List.filter_map (function ExternFuncT ft -> Some ft | _ -> None)
@@ -310,17 +272,59 @@ let expand_def_type (dt : def_type) : str_type =
   st
 
 
-(* Projections *)
+(* Conversions & Projections *)
+
+let num_type_of_addr_type = function
+  | I32AT -> I32T
+  | I64AT -> I64T
+
+let addr_type_of_num_type = function
+  | I32T -> I32AT
+  | I64T -> I64AT
+  | _ -> assert false
 
 let unpacked_storage_type = function
   | ValStorageT t -> t
   | PackStorageT _ -> NumT I32T
+
+let unpacked_field_type (FieldT (_mut, t)) = unpacked_storage_type t
+
+let as_def_heap_type (ht : heap_type) : def_type =
+  match ht with
+  | DefHT def -> def
+  | _ -> assert false
+
+let as_func_str_type (st : str_type) : func_type =
+  match st with
+  | DefFuncT ft -> ft
+  | _ -> assert false
 
 let as_cont_str_type (dt : str_type) : cont_type =
   match dt with
   | DefContT ct -> ct
   | _ -> assert false
 
+let as_struct_str_type (st : str_type) : struct_type =
+  match st with
+  | DefStructT st -> st
+  | _ -> assert false
+
+let as_array_str_type (st : str_type) : array_type =
+  match st with
+  | DefArrayT at -> at
+  | _ -> assert false
+
+let as_cont_func_heap_type (ht : heap_type) : func_type =
+  let ContT ht' = as_cont_str_type (expand_def_type (as_def_heap_type ht)) in
+  as_func_str_type (expand_def_type (as_def_heap_type ht'))
+
+let as_cont_func_ref_type (rt : val_type) : func_type =
+  match rt with
+  | RefT (_, ht) -> as_cont_func_heap_type ht
+  | _ -> assert false
+
+let extern_type_of_import_type (ImportT (et, _, _)) = et
+let extern_type_of_export_type (ExportT (et, _)) = et
 
 (* String conversion *)
 

--- a/test/core/stack-switching/cont.wast
+++ b/test/core/stack-switching/cont.wast
@@ -927,6 +927,38 @@
 )
 (assert_return (invoke "main") (i32.const 10))
 
+(module
+  (type $f1 (func (result i32)))
+  (type $c1 (cont $f1))
+  (type $f2 (func (param (ref null $c1)) (result i32)))
+  (type $c2 (cont $f2))
+  (type $f3 (func (param (ref null $c2)) (result i32)))
+  (type $c3 (cont $f3))
+  (tag $e (result i32))
+
+  (func $fn_1 (param (ref null $c2)) (result i32)
+    (local.get 0)
+    (switch $c2 $e)
+    (i32.const 24)
+  )
+  (elem declare func $fn_1)
+
+  (func $fn_2 (result i32)
+    (cont.new $c3 (ref.func $fn_1))
+    (switch $c3 $e)
+    (drop)
+    (i32.const -1)
+  )
+  (elem declare func $fn_2)
+
+  (func (export "main") (result i32)
+    (cont.new $c1 (ref.func $fn_2))
+    (resume $c1 (on $e switch))
+  )
+)
+
+(assert_return (invoke "main") (i32.const -1))
+
 ;; Syntax: check unfolded forms
 (module
   (type $ft (func))


### PR DESCRIPTION
This patch fixes a bug with the arity of the continuation reference
generated by a `switch` (aka the current continuation). Its arity was
mistakenly derived from the switch-tag's codomain. The arity of the
current continuation can be obtained at the `switch` point by
deconstructing the type annotation on it.

Fixes #103.