### PR TITLE
Reduction semantics

### DIFF
--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -755,7 +755,7 @@ We also introduce tag uses, which can be either tag indices or tag addresses:
     - iff `C.tags[$e] = tag $ft`
     - and `C.types[$ft] ~~ func [t1*] -> [t2*]`
   - `ea : [t1*] -> [t2*]`
-    - iff `S.tags[ea].type ~~ [t1*] -> [t2*]`
+    - iff `S.tags[ea].type ~~ func [t1*] -> [t2*]`
 
 ### Instructions
 

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -855,14 +855,14 @@ of event, even if they use the correct tag.
 * `(suspend.addr ea)` represents a `(suspend $e)` instruction where the tag index `$e` has been replaced with the physical address `ea` of the tag.
   - `suspend.addr ea : [t1*] -> [t2*]`
     - iff `S.tags[ea].type ~~ [t1*] -> [t2*]`
-   
+
 * `(switch.addr $ct ea)` represents a `(switch $ct $e)` instruction where the tag index `$e` has been replaced with the physical address `ea` of the tag.
   - `switch.addr $ct ea : [t1* (ref null $ct1)] -> [t2*]`
     - iff `S.tags[$e].type ~~ [] -> [t*]`
     - and `C.types[$ct] ~~ cont [t1* (ref null? $ct2)] -> [te1*]`
     - and `te1* <: t*`
     - and `C.types[$ct2] ~~ cont [t2*] -> [te2*]`
-    - and `t* <: te2*` 
+    - and `t* <: te2*`
 
 * `(prompt{<hdl>*} <instr>* end)` represents an active handler
   - `(prompt{hdl*}? instr* end) : [] -> [t*]`
@@ -942,10 +942,12 @@ H^ea ::=
 * `S; F; (ref.cont ca) (resume_throw $ct $e hdl*)  -->  S; F; trap`
   - iff `S.conts[ca] = epsilon`
 
-* `S; F; v^m (ref.cont ca) (resume_throw $ct $e hdl*)  -->  S'; F; prompt{hdl'*} E[v^m (throw $e)] end`
+* `S; F; v^m (ref.cont ca) (resume_throw $ct $e hdl*)  -->  S''; F; prompt{hdl'*} E[(ref.exn |S'.exns|) throw_ref] end`
   - iff `S.conts[ca] = (E : n)`
-  - and `S.tags[F.tags[$e]].type ~~ [t1^m] -> [t2*]`
-  - and `S' = S with conts[ca] = epsilon`
+  - and `ta = S.tags[F.tags[$e]]`
+  - and `ta.type ~~ [t1^m] -> [t2*]`
+  - and `S' = S with exns += {ta, v^m}`
+  - and `S'' = S' with conts[ca] = epsilon`
   - and `hdl'*` is obtained by translating the `<tagidx>` from `hdl*` into `<tagaddr>` using `F.tag`:
        - if `on $a $l` is in `hdl*` and `F.tags[$e]=ea`, then `ea $l` is in `hdl'*`
        - if `on $a switch` is in `hdl'*` and `F.tags[$e]=ea`, then `ea switch` is in `hdl'*`

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -857,7 +857,7 @@ of event, even if they use the correct tag.
     - iff `S.tags[ea].type ~~ [t1*] -> [t2*]`
    
 * `(switch.addr $ct ea)` represents a `(switch $ct $e)` instruction where the tag index `$e` has been replaced with the physical address `ea` of the tag.
-  - `switch.addr $ct ea : : [t1* (ref null $ct1)] -> [t2*]`
+  - `switch.addr $ct ea : [t1* (ref null $ct1)] -> [t2*]`
     - iff `S.tags[$e].type ~~ [] -> [t*]`
     - and `C.types[$ct] ~~ cont [t1* (ref null? $ct2)] -> [te1*]`
     - and `te1* <: t*`

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -751,7 +751,7 @@ In other words, the return type of tag types is allowed to be non-empty.
 We also introduce tag uses, which can be either tag indices or tag addresses:
 
 - `taguse ::= tagidx | tagaddr`
-  - `$a : [t1*] -> [t2*]`
+  - `$e : [t1*] -> [t2*]`
     - iff `C.tags[$e] = tag $ft`
     - and `C.types[$ft] ~~ func [t1*] -> [t2*]`
   - `ea : [t1*] -> [t2*]`
@@ -933,6 +933,11 @@ H^ea ::=
 
 * `S; F; (switch $ct $e) --> S; F; (switch $ct ea)`
   - iff `ea = F.module.tags[$e]`
+
+* `S; F; (ref.null t) (switch $ct ea) --> S; F; trap`
+
+* `S; F; (ref.cont ca) (switch $ct ea) --> S; F; trap`
+  - iff `S.conts[ca] = epsilon`
 
 * `S; F; (prompt{hdl1* (on ea switch) hdl2*} H^ea[v^n (ref.cont ca) (switch $ct ea)] end) --> S''; F; prompt{hdl1* (on ea switch) hdl2*} E[v^n (ref.cont |S.conts|)] end`
   - iff  `S.conts[ca] = (E : n')`

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -861,11 +861,11 @@ of event, even if they use the correct tag.
 * `(prompt{<hdl>*} <instr>* end)` represents an active handler
   - `(prompt{((a $l) | (b switch))*}? instr* end) : [t1*] -> [t2*]`
     - iff `instr* : [t1*] -> [t2*]`
-    - and `(S.tags[a].type = [te1*] -> [te2*])*`
-    - and `(S.tags[b].type = [] -> [te2*])*`
+    - and `(S.tags[a].type ~~ [te1*] -> [te2*])*`
+    - and `(S.tags[b].type ~~ [] -> [te2*])*`
     - and `(label $l : [te1'* (ref null? $ct')])*`
     - and `([te1*] <: [te1'*])*`
-    - and `($ct' = cont $ft')*`
+    - and `($ct' ~~ cont $ft')*`
     - and `([te2*] -> [t2*] <: $ft')*`
 
 The administrative structure `hdl` is defined as.

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -941,7 +941,7 @@ H^ea ::=
   - and `S.tags[ea].type ~~ [t1^n] -> [t2^m]`
   - and `S' = S with conts += (H^ea : m)`
 
-* `S; F; (prompt{hdl* (ea switch) hdl2*} H^ea[v^n (ref.cont ca) (switch $ct $e)] end) --> S''; F; prompt{hdl1* (ea switch) hdl2*} E[v^n (ref.cont |S.conts|)] end`
+* `S; F; (prompt{hdl1* (ea switch) hdl2*} H^ea[v^n (ref.cont ca) (switch $ct $e)] end) --> S''; F; prompt{hdl1* (ea switch) hdl2*} E[v^n (ref.cont |S.conts|)] end`
   - iff  `S.conts[ca] = (E : n')`
   - and `n' = 1 + n`
   - and `ea notin ea1*`

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -898,7 +898,7 @@ H^ea ::=
 
 * `S; F; (ref.null t) (cont.bind $ct $ct')  -->  S; F; trap`
 
-* `S; F; (ref.cont ca) (cont.bind $ct $ct')  -->  S'; F; trap`
+* `S; F; (ref.cont ca) (cont.bind $ct $ct')  -->  S; F; trap`
   - iff `S.conts[ca] = epsilon`
 
 * `S; F; v^n (ref.cont ca) (cont.bind $ct $ct')  -->  S'; F; (ref.const |S.conts|)`

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -878,11 +878,11 @@ where
 
 * `(a $l)` represents a tag-label association
  - `(a $l) : [t2*]`
-    - iff `(S.tags[a].type ~~ [te1*] -> [te2*])*`
-    - and `(label $l : [te1'* (ref null? $ct')])*`
-    - and `([te1*] <: [te1'*])*`
-    - and `($ct' ~~ cont $ft')*`
-    - and `([te2*] -> [t2*] <: $ft')*`
+    - iff `S.tags[a].type ~~ [te1*] -> [te2*]`
+    - and `label $l : [te1'* (ref null? $ct')]`
+    - and `[te1*] <: [te1'*]`
+    - and `$ct' ~~ cont $ft'`
+    - and `[te2*] -> [t2*] <: $ft'`
 
 * `(a switch)` represents a tag-switch association
  - `(a switch) : [t2*]`

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -855,7 +855,7 @@ of event, even if they use the correct tag.
 * `(prompt{<hdl>*} <instr>* end)` represents an active handler
   - `(prompt{hdl*}? instr* end) : [t1*] -> [t2*]`
     - iff `instr* : [t1*] -> [t2*]`
-    - and `(hdl : [t2^*])*`
+    - and `(hdl : [t2*])*`
 
 The administrative structure `hdl` is defined as
 ```

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -886,7 +886,7 @@ where
 
 * `(a switch)` represents a tag-switch association
  - `(a switch) : [t2*]`
-      - iff `(S.tags[b].type ~~ [] -> [te2*])*`
+      - iff `S.tags[a].type ~~ [] -> [te2*]`
   
 
 #### Handler contexts

--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -836,10 +836,10 @@ of event, even if they use the correct tag.
 #### Store extensions
 
 * New store component `conts` for allocated continuations
-  - `S ::= {..., conts <cont>?*}`
+  - `S ::= {..., conts <continst>?*}`
 
 * A continuation is a context annotated with its hole's arity
-  - `cont ::= (E : n)`
+  - `continst ::= (E : n)`
 
 
 #### Administrative instructions
@@ -886,7 +886,7 @@ where
 
 * `(a switch)` represents a tag-switch association
  - `(a switch) : [t2*]`
-      - iff `S.tags[a].type ~~ [] -> [te2*]`
+      - iff `S.tags[a].type ~~ [] -> [t2*]`
   
 
 #### Handler contexts
@@ -933,9 +933,9 @@ H^ea ::=
 * `S; F; v^n (ref.cont ca) (resume $ct hdl*)  -->  S'; F; prompt{hdl'*} E[v^n] end`
   - iff `S.conts[ca] = (E : n)`
   - and `S' = S with conts[ca] = epsilon`
-  - and `hdl'*` is obtained by translating the `<tagidx>` from `hdl*` into `<tagaddr>` using `F.tag`:
-       - if `on $a $l` is in `hdl*` and `F.tags[$e]=ea`, then `ea $l` is in `hdl'*`
-       - if `on $a switch` is in `hdl'*` and `F.tags[$e]=ea`, then `ea switch` is in `hdl'*`
+  - and `hdl'*` by mapping the following translation onto `hdl*`:
+       - a clause of the form `on $a $l` becomes `ea $l` if `F.module.tags[$a]=ea` 
+       - a clause of the form `on $a switch` becomes `ea switch` if `F.module.tags[$a]=ea` 
 
 * `S; F; (ref.null t) (resume_throw $ct $e hdl*)  -->  S; F; trap`
 
@@ -944,31 +944,31 @@ H^ea ::=
 
 * `S; F; v^m (ref.cont ca) (resume_throw $ct $e hdl*)  -->  S''; F; prompt{hdl'*} E[(ref.exn |S'.exns|) throw_ref] end`
   - iff `S.conts[ca] = (E : n)`
-  - and `ta = S.tags[F.tags[$e]]`
+  - and `ta = S.tags[F.module.tags[$e]]`
   - and `ta.type ~~ [t1^m] -> [t2*]`
   - and `S' = S with exns += {ta, v^m}`
   - and `S'' = S' with conts[ca] = epsilon`
-  - and `hdl'*` is obtained by translating the `<tagidx>` from `hdl*` into `<tagaddr>` using `F.tag`:
-       - if `on $a $l` is in `hdl*` and `F.tags[$e]=ea`, then `ea $l` is in `hdl'*`
-       - if `on $a switch` is in `hdl'*` and `F.tags[$e]=ea`, then `ea switch` is in `hdl'*`
+  - and `hdl'*` by mapping the following translation onto `hdl*`:
+       - a clause of the form `on $a $l` becomes `ea $l` if `F.module.tags[$a]=ea` 
+       - a clause of the form `on $a switch` becomes `ea switch` if `F.module.tags[$a]=ea`
 
 * `S; F; (prompt{hdl*} v* end)  -->  S; F; v*`
 
 * `S; F; (suspend $e) --> S; F; (suspend.addr ea)`
-  - iff `ea = F.tags[$e]`
+  - iff `ea = F.module.tags[$e]`
 
 * `S; F; (prompt{hdl1* (ea $l) hdl2*} H^ea[v^n (suspend.addr ea)] end)  --> S'; F; v^n (ref.cont |S.conts|) (br $l)`
-  - iff `ea notin tagaddr(hdl1*)`
+  - iff `forall $l', (ea $l') notin hdl1*`
   - and `S.tags[ea].type ~~ [t1^n] -> [t2^m]`
   - and `S' = S with conts += (H^ea : m)`
 
 * `S; F; (switch $ct $e) --> S; F; (switch.addr $ct ea)`
-  - iff `ea = F.tags[$e]`
+  - iff `ea = F.module.tags[$e]`
 
 * `S; F; (prompt{hdl1* (ea switch) hdl2*} H^ea[v^n (ref.cont ca) (switch.addr $ct ea)] end) --> S''; F; prompt{hdl1* (ea switch) hdl2*} E[v^n (ref.cont |S.conts|)] end`
   - iff  `S.conts[ca] = (E : n')`
   - and `n' = 1 + n`
-  - and `ea notin tagaddr(hdl1*)`
+  - and `(switch ea) notin hdl1*`
   - and `$ct ~~ cont $ft`
   - and `$ft ~~ [t1* (ref $ct2)] -> [t2*]`
   - and `$ct2 ~~ cont $ft2`


### PR DESCRIPTION
This patch populates the "Execution" section of the Explainer document with the reduction rules for stack switching.

Resolves #91.