### PR TITLE
Fixed tags with recursive type definitions

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -125,10 +125,6 @@ let check_limits {min; max} range at msg =
     require (I64.le_u min max) at
       "size minimum must not be greater than maximum"
 
-let check_def_type (c : context) (t : def_type) at =
-  match t with
-  | DefT (RecT sts, i) -> assert (i < Lib.List32.length sts)
-
 let check_num_type (c : context) (t : num_type) at =
   ()
 
@@ -143,8 +139,7 @@ let check_heap_type (c : context) (t : heap_type) at =
   | ExnHT | NoExnHT
   | ExternHT | NoExternHT -> ()
   | VarHT (StatX x) -> let _dt = type_ c (x @@ at) in ()
-  | VarHT (RecX _) -> assert false
-  | DefHT dt -> check_def_type c dt at
+  | VarHT (RecX _) | DefHT _ -> assert false
   | BotHT -> ()
 
 let check_ref_type (c : context) (t : ref_type) at =
@@ -185,7 +180,9 @@ let check_func_type (c : context) (ft : func_type) at =
 
 let check_cont_type (c : context) (ct : cont_type) at =
   match ct with
-  | ContT ht -> let _dt = func_type_of_heap_type c ht at in ()
+  | ContT (VarHT (StatX x)) ->
+    let _dt = func_type c (x @@ at) in ()
+  | _ -> assert false
 
 let check_table_type (c : context) (tt : table_type) at =
   let TableT (at_, lim, t) = tt in
@@ -208,7 +205,7 @@ let check_memory_type (c : context) (mt : memory_type) at =
 
 let check_tag_type (c : context) (et : tag_type) at =
   match et with
-  | TagT dt -> check_func_type c (as_func_str_type (expand_def_type dt)) at
+  | TagT dt -> let _ft = as_func_str_type (expand_def_type dt) in ()
 
 let check_global_type (c : context) (gt : global_type) at =
   let GlobalT (_mut, t) = gt in

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -127,7 +127,7 @@ let check_limits {min; max} range at msg =
 
 let check_def_type (c : context) (t : def_type) at =
   match t with
-  | DefT (RecT sts, i) -> assert Int32.(compare i (of_int (List.length sts)) < 0)
+  | DefT (RecT sts, i) -> assert (i < Lib.List32.length sts)
 
 let check_num_type (c : context) (t : num_type) at =
   ()

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -125,6 +125,10 @@ let check_limits {min; max} range at msg =
     require (I64.le_u min max) at
       "size minimum must not be greater than maximum"
 
+let check_def_type (c : context) (t : def_type) at =
+  match t with
+  | DefT (RecT sts, i) -> assert Int32.(compare i (of_int (List.length sts)) < 0)
+
 let check_num_type (c : context) (t : num_type) at =
   ()
 
@@ -139,7 +143,8 @@ let check_heap_type (c : context) (t : heap_type) at =
   | ExnHT | NoExnHT
   | ExternHT | NoExternHT -> ()
   | VarHT (StatX x) -> let _dt = type_ c (x @@ at) in ()
-  | VarHT (RecX _) | DefHT _ -> assert false
+  | VarHT (RecX _) -> assert false
+  | DefHT dt -> check_def_type c dt at
   | BotHT -> ()
 
 let check_ref_type (c : context) (t : ref_type) at =
@@ -180,9 +185,7 @@ let check_func_type (c : context) (ft : func_type) at =
 
 let check_cont_type (c : context) (ct : cont_type) at =
   match ct with
-  | ContT (VarHT (StatX x)) ->
-    let _dt = func_type c (x @@ at) in ()
-  | _ -> assert false
+  | ContT ht -> let _dt = func_type_of_heap_type c ht at in ()
 
 let check_table_type (c : context) (tt : table_type) at =
   let TableT (at_, lim, t) = tt in

--- a/test/core/tag.wast
+++ b/test/core/tag.wast
@@ -21,6 +21,14 @@
 ;;   "non-empty tag result type"
 ;; )
 
+;; Mutually recursive types
+(module
+  (rec
+    (type $f (func (param (ref null $c))))
+    (type $c (cont $f))
+  )
+  (tag (type $f))
+)
 
 ;; Link-time typing
 


### PR DESCRIPTION
This PR fixes the following MWE:
```wat
(module
  (rec
    (type (func (param (ref null 1))))
    (type (cont 0))
  )
  (tag (type 0))
)
```