### PR TITLE
Statically disallow casts over continuations

### DIFF
--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -900,8 +900,8 @@ critical use-cases requires multi-shot continuations.
 
 ## Specification changes
 
-This proposal is based on the [function references proposal](https://github.com/WebAssembly/function-references)
-and [exception handling proposal](https://github.com/WebAssembly/exception-handling).
+This proposal is based on Wasm 3.0, specifically [function references](https://github.com/WebAssembly/function-references)
+and [exception handling](https://github.com/WebAssembly/exception-handling).
 
 ### Types
 
@@ -997,6 +997,15 @@ This abbreviation will be formalised with an auxiliary function or other means i
     - and `te1* <: t*`
     - and `C.types[$ct2] ~~ cont [t2*] -> [te2*]`
     - and `t* <: te2*`
+
+In addition to these new rules, the existing rules for cast instructions `ref.test`, `ref.cast`, `br_on_cast`, and `br_on_cast_fail` are amended with an additional side condition to rule out casting of continuation types:
+
+  - iff `rt castable`
+
+where `rt` is the respective target type of the cast instruction, and the `castable` predicate is defined as follows:
+
+- `rt castable`
+  - iff not (rt <: (ref null cont))
 
 ### Execution
 

--- a/test/core/stack-switching/validation.wast
+++ b/test/core/stack-switching/validation.wast
@@ -796,3 +796,108 @@
   )
   "unknown tag"
 )
+
+
+;; Illegal casts
+
+(assert_invalid
+  (module
+    (func (drop (ref.test contref (unreachable))))
+  )
+  "invalid cast"
+)
+(assert_invalid
+  (module
+    (func (drop (ref.test nullcontref (unreachable))))
+  )
+  "invalid cast"
+)
+(assert_invalid
+  (module
+    (type $f (func))
+    (type $c (cont $f))
+    (func (drop (ref.test (ref $c) (unreachable))))
+  )
+  "invalid cast"
+)
+
+(assert_invalid
+  (module
+    (func (drop (ref.cast contref (unreachable))))
+  )
+  "invalid cast"
+)
+(assert_invalid
+  (module
+    (func (drop (ref.cast nullcontref (unreachable))))
+  )
+  "invalid cast"
+)
+(assert_invalid
+  (module
+    (type $f (func))
+    (type $c (cont $f))
+    (func (drop (ref.cast (ref $c) (unreachable))))
+  )
+  "invalid cast"
+)
+
+(assert_invalid
+  (module
+    (func
+      (block (result contref) (br_on_cast 0 contref contref (unreachable)))
+      (drop)
+    )
+  )
+  "invalid cast"
+)
+(assert_invalid
+  (module
+    (func
+      (block (result contref) (br_on_cast 0 nullcontref nullcontref (unreachable)))
+      (drop)
+    )
+  )
+  "invalid cast"
+)
+(assert_invalid
+  (module
+    (type $f (func))
+    (type $c (cont $f))
+    (func
+      (block (result contref) (br_on_cast 0 (ref $c) (ref $c) (unreachable)))
+      (drop)
+    )
+  )
+  "invalid cast"
+)
+
+(assert_invalid
+  (module
+    (func
+      (block (result contref) (br_on_cast_fail 0 contref contref (unreachable)))
+      (drop)
+    )
+  )
+  "invalid cast"
+)
+(assert_invalid
+  (module
+    (func
+      (block (result contref) (br_on_cast_fail 0 nullcontref nullcontref (unreachable)))
+      (drop)
+    )
+  )
+  "invalid cast"
+)
+(assert_invalid
+  (module
+    (type $f (func))
+    (type $c (cont $f))
+    (func
+      (block (result contref) (br_on_cast_fail 0 (ref $c) (ref $c) (unreachable)))
+      (drop)
+    )
+  )
+  "invalid cast"
+)


### PR DESCRIPTION
Explainer, reference interpreter, and test suite additions. Resolves #115.