### PR TITLE
Add missing `null?` in switch rule

### DIFF
--- a/proposals/stack-switching/Explainer.md
+++ b/proposals/stack-switching/Explainer.md
@@ -617,7 +617,7 @@ switch.
   switch $ct1 $e : [t1* (ref null $ct1)] -> [t2*]
   where:
   - $e : [] -> [t*]
-  - $ct1 = cont [t1* (ref $ct2)] -> [t*]
+  - $ct1 = cont [t1* (ref null? $ct2)] -> [t*]
   - $ct2 = cont [t2*] -> [t*]
 ```
 


### PR DESCRIPTION
This was missing in the introduction to switch, but was already included in the more complete rules later in the document.
